### PR TITLE
update PIP defintions to require standard SKU to enable

### DIFF
--- a/services/Network/publicIPAddresses/Deploy-PIP-BytesInDDOSAttack-Alert.json
+++ b/services/Network/publicIPAddresses/Deploy-PIP-BytesInDDOSAttack-Alert.json
@@ -126,6 +126,10 @@
             "equals": "Microsoft.Network/publicIPAddresses"
           },
           {
+            "field": "Microsoft.Network/publicIPAddresses/sku.name",
+            "equals": "Standard"
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisable'), ']')]",
             "notEquals": "true"
           }

--- a/services/Network/publicIPAddresses/Deploy-PIP-DDOSAttack-Alert.json
+++ b/services/Network/publicIPAddresses/Deploy-PIP-DDOSAttack-Alert.json
@@ -126,6 +126,10 @@
             "equals": "Microsoft.Network/publicIPAddresses"
           },
           {
+            "field": "Microsoft.Network/publicIPAddresses/sku.name",
+            "equals": "Standard"
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisable'), ']')]",
             "notEquals": "true"
           }

--- a/services/Network/publicIPAddresses/Deploy-PIP-PacketsInDDOS-Alert.json
+++ b/services/Network/publicIPAddresses/Deploy-PIP-PacketsInDDOS-Alert.json
@@ -126,6 +126,10 @@
             "equals": "Microsoft.Network/publicIPAddresses"
           },
           {
+            "field": "Microsoft.Network/publicIPAddresses/sku.name",
+            "equals": "Standard"
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisable'), ']')]",
             "notEquals": "true"
           }


### PR DESCRIPTION
update policyRules for other PIP definitions  to check for standard SKU as basic does not include metric checks